### PR TITLE
Fix Jarvis chat API and add basic test

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Configuration for the application is managed via environment variables, typicall
     cp .env.example .env
     ```
 
+    For the frontend, create `frontend/.env.local` and set `NEXT_PUBLIC_API_URL` to the backend URL (e.g. `http://localhost:8000`).
+
 2.  **Key Environment Variables:**
     Open the `.env` file and set the following variables:
 
@@ -140,6 +142,23 @@ uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 *   `--port 8000`: Specifies the port to run on.
 
 The application will be available at `http://localhost:8000` or `http://<your-ip>:8000`.
+
+### Jarvis AI Assistant
+
+To enable the optional Jarvis assistant powered by a local Ollama server:
+
+1. Install and run [Ollama](https://ollama.ai/) locally. The API should be available on `http://localhost:11434`.
+2. Start the FastAPI application as shown above.
+3. Use the `/jarvis/ask` endpoint to chat with Jarvis. Example:
+
+```bash
+curl -X POST "http://localhost:8000/jarvis/ask" \
+  -H "Authorization: Bearer <ACCESS_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"project_id": 1, "role": "user", "content": "Hello"}'
+```
+
+Jarvis will send the prompt to Ollama and return the AI response while storing the conversation in the database.
 
 ## Seeding Initial Data
 

--- a/app/api/jarvis.py
+++ b/app/api/jarvis.py
@@ -2,6 +2,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from typing import List, Optional
+import httpx
 from app.schemas.jarvis import (
     ChatMessageCreate, ChatMessageRead, ChatMessageUpdate, ChatMessageShort
 )
@@ -9,6 +10,10 @@ from app.crud.jarvis import (
     save_message,
     get_history,
     delete_history_for_project,
+    get_message_by_id,
+    update_message,
+    soft_delete_message,
+    ChatControllerError,
 )
 from app.dependencies import get_db, get_current_active_user
 from app.schemas.response import SuccessResponse
@@ -18,6 +23,89 @@ import logging
 
 router = APIRouter(prefix="/jarvis", tags=["Jarvis"])
 logger = logging.getLogger("DevOS.JarvisAPI")
+
+
+@router.post("/chat/", response_model=ChatMessageRead)
+def create_chat_message(
+    data: ChatMessageCreate,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    """Создает новое сообщение (аналог /message)."""
+    try:
+        msg = save_message(
+            db=db,
+            project_id=data.project_id,
+            role=data.role,
+            content=data.content,
+            timestamp=data.timestamp,
+            metadata=data.metadata,
+            author=data.author or current_user.username,
+            ai_notes=data.ai_notes,
+            attachments=data.attachments,
+            is_deleted=data.is_deleted,
+        )
+        return msg
+    except Exception as e:
+        logger.error(f"Failed to save chat message: {e}")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.get("/chat/", response_model=List[ChatMessageShort])
+def list_chat_messages(
+    project_id: int,
+    limit: Optional[int] = Query(None, ge=1, le=100),
+    offset: Optional[int] = Query(None, ge=0),
+    include_deleted: bool = False,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    """Возвращает сообщения проекта."""
+    try:
+        messages = get_history(db, project_id, limit=limit, offset=offset, include_deleted=include_deleted)
+        return [ChatMessageShort.from_orm(m) for m in messages]
+    except Exception as e:
+        logger.error(f"Failed to list chat messages: {e}")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.get("/chat/{message_id}", response_model=ChatMessageRead)
+def get_chat_message(
+    message_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    msg = get_message_by_id(db, message_id)
+    if not msg:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Message not found")
+    return msg
+
+
+@router.patch("/chat/{message_id}", response_model=ChatMessageRead)
+def patch_chat_message(
+    message_id: int,
+    data: ChatMessageUpdate,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    try:
+        msg = update_message(db, message_id, data.dict(exclude_unset=True))
+        return msg
+    except ChatControllerError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.delete("/chat/{message_id}", response_model=SuccessResponse)
+def delete_chat_message(
+    message_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    try:
+        result = soft_delete_message(db, message_id)
+        return SuccessResponse(result=result, detail="Message deleted")
+    except ChatControllerError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 @router.post("/message", response_model=ChatMessageRead)
 def post_message(
@@ -101,3 +189,42 @@ def last_messages(
     except Exception as e:
         logger.error(f"Failed to get last messages for project {project_id}: {e}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.post("/ask", response_model=ChatMessageRead)
+async def ask_jarvis(
+    data: ChatMessageCreate,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_active_user),
+):
+    """Отправляет запрос локальному Ollama и сохраняет ответ."""
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(
+                "http://localhost:11434/api/generate",
+                json={"model": "llama3", "prompt": data.content, "stream": False},
+            )
+            resp.raise_for_status()
+            ai_content = resp.json().get("response", "")
+    except Exception as e:
+        logger.error(f"Ollama request failed: {e}")
+        raise HTTPException(status_code=503, detail="Ollama service unavailable")
+
+    user_msg = save_message(
+        db=db,
+        project_id=data.project_id,
+        role=data.role,
+        content=data.content,
+        author=current_user.username,
+        attachments=data.attachments,
+        is_deleted=data.is_deleted,
+    )
+
+    ai_msg = save_message(
+        db=db,
+        project_id=data.project_id,
+        role="jarvis",
+        content=ai_content,
+        author="jarvis",
+    )
+    return ai_msg

--- a/app/schemas/jarvis.py
+++ b/app/schemas/jarvis.py
@@ -1,5 +1,5 @@
 #app/schemas/jarvis.py
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from typing import Optional, List, Dict, Any
 from datetime import datetime
 
@@ -13,11 +13,18 @@ class ChatMessageBase(BaseModel):
     role: str = Field(..., example="user", description="Роль: user, assistant, system")
     content: str = Field(..., example="Let's plan our next sprint!", description="Текст сообщения")
     timestamp: Optional[datetime] = Field(None, example="2024-06-01T15:00:00Z", description="Время сообщения")
-    metadata: Optional[Dict[str, Any]] = Field(None, example={"action": "ref", "source": "gpt"}, description="Служебные метаданные")
+    metadata: Optional[Dict[str, Any]] = Field(
+        None,
+        alias="metadata_",
+        example={"action": "ref", "source": "gpt"},
+        description="Служебные метаданные",
+    )
     author: Optional[str] = Field(None, example="john.doe", description="Имя/логин автора (если не user_id)")
     ai_notes: Optional[str] = Field(None, example="AI summary of the conversation.", description="AI-комментарии")
     attachments: List[Attachment] = Field(default_factory=list, description="Вложения (файлы, картинки и пр.)")
     is_deleted: bool = Field(False, description="Soft-delete flag")
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 class ChatMessageCreate(ChatMessageBase):
     """
@@ -30,10 +37,12 @@ class ChatMessageUpdate(BaseModel):
     ChatMessageUpdate — схема для обновления сообщения.
     """
     content: Optional[str] = None
-    metadata: Optional[Dict[str, Any]] = None
+    metadata: Optional[Dict[str, Any]] = Field(None, alias="metadata_")
     author: Optional[str] = None
     ai_notes: Optional[str] = None
     attachments: Optional[List[Attachment]] = None
+
+    model_config = ConfigDict(populate_by_name=True)
     is_deleted: Optional[bool] = None
 
 class ChatMessageRead(ChatMessageBase):
@@ -42,8 +51,7 @@ class ChatMessageRead(ChatMessageBase):
     """
     id: int
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 class ChatMessageShort(BaseModel):
     """
@@ -54,5 +62,4 @@ class ChatMessageShort(BaseModel):
     content: str
     timestamp: Optional[datetime] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/app/tests/api/test_jarvis_api.py
+++ b/app/tests/api/test_jarvis_api.py
@@ -1,0 +1,37 @@
+import uuid
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.user import User as UserModel
+from app.models.project import Project as ProjectModel
+from app.crud.project import create_project as crud_create_project
+
+
+@pytest.fixture
+def jarvis_project(db: Session, test_user: UserModel) -> ProjectModel:
+    data = {"name": f"JarvisProj-{uuid.uuid4().hex[:6]}", "author_id": test_user.id}
+    return crud_create_project(db, data)
+
+
+def test_create_and_get_message(
+    client: TestClient,
+    normal_user_token_headers: dict,
+    jarvis_project: ProjectModel,
+):
+    payload = {
+        "project_id": jarvis_project.id,
+        "role": "user",
+        "content": "Hi",
+        "attachments": [],
+        "is_deleted": False,
+    }
+    resp = client.post("/jarvis/chat/", json=payload, headers=normal_user_token_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["content"] == "Hi"
+    msg_id = data["id"]
+
+    resp_get = client.get(f"/jarvis/chat/{msg_id}", headers=normal_user_token_headers)
+    assert resp_get.status_code == 200
+    assert resp_get.json()["id"] == msg_id


### PR DESCRIPTION
## Summary
- add REST endpoints under `/jarvis/chat/` and `/jarvis/ask`
- support updating chat messages in CRUD
- document Jarvis usage and frontend environment config
- create schema aliases for chat message metadata
- test basic create/get flow for Jarvis messages

## Testing
- `pip install -q -r requirements.txt`
- `pytest app/tests/api/test_jarvis_api.py::test_create_and_get_message -q`

------
https://chatgpt.com/codex/tasks/task_e_684361151354832cbc2ad9d9515d4ba4