### PR TITLE
Fix Jarvis API calls in frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,4 +34,3 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-npx shadcn@latest add label

--- a/frontend/src/app/lib/api.tsx
+++ b/frontend/src/app/lib/api.tsx
@@ -362,18 +362,25 @@ export function deleteAIContext(id: number, token?: string | null): Promise<Succ
 }
 
 // --- JARVIS CHAT ---
-export function listChatMessages(params: Record<string, any> = {}, token?: string | null): Promise<ChatMessageShort[]> {
-  return apiFetch<ChatMessageShort[]>("/jarvis/chat/", { params, token });
+export function listChatMessages(
+  projectId: number,
+  params: { limit?: number; offset?: number } = {},
+  token?: string | null,
+): Promise<ChatMessageRead[]> {
+  return apiFetch<ChatMessageRead[]>(`/jarvis/history/${projectId}`, { params, token });
 }
 export function createChatMessage(data: ChatMessageCreate, token?: string | null): Promise<ChatMessageRead> {
-  return apiFetch<ChatMessageRead>("/jarvis/chat/", { method: "POST", body: data, token });
+  return apiFetch<ChatMessageRead>("/jarvis/message", { method: "POST", body: data, token });
 }
-export function getChatMessage(id: number, token?: string | null): Promise<ChatMessageRead> {
-  return apiFetch<ChatMessageRead>(`/jarvis/chat/${id}`, { token });
+export function deleteChatHistory(projectId: number, token?: string | null): Promise<SuccessResponse> {
+  return apiFetch<SuccessResponse>(`/jarvis/history/${projectId}`, { method: "DELETE", token });
 }
-export function updateChatMessage(id: number, data: ChatMessageUpdate, token?: string | null): Promise<ChatMessageRead> {
-  return apiFetch<ChatMessageRead>(`/jarvis/chat/${id}`, { method: "PATCH", body: data, token });
-}
-export function deleteChatMessage(id: number, token?: string | null): Promise<SuccessResponse> {
-  return apiFetch<SuccessResponse>(`/jarvis/chat/${id}`, { method: "DELETE", token });
+export function lastChatMessages(
+  projectId: number,
+  n?: number,
+  token?: string | null,
+): Promise<ChatMessageShort[]> {
+  const params: Record<string, any> = {};
+  if (n !== undefined) params.n = n;
+  return apiFetch<ChatMessageShort[]>(`/jarvis/history/${projectId}/last`, { params, token });
 }

--- a/frontend/src/app/lib/types.tsx
+++ b/frontend/src/app/lib/types.tsx
@@ -64,16 +64,6 @@ export interface SuccessResponse {
   detail?: string | null;
 }
 
-export interface ErrorDetail {
-  code: string;
-  message: string;
-  details?: any;
-}
-
-export interface ErrorResponse {
-  error: ErrorDetail;
-}
-
 export interface ListResponse<T> {
   results: T[];
   total_count?: number;

--- a/frontend/src/components/JarvisPanel.tsx
+++ b/frontend/src/components/JarvisPanel.tsx
@@ -3,7 +3,10 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { createChatMessage, listChatMessages } from "../app/lib/api";
+import {
+  createChatMessage,
+  listChatMessages,
+} from "../app/lib/api";
 import type { ChatMessageRead, ChatMessageCreate } from "../app/lib/types";
 import { Loader2 } from "lucide-react";
 
@@ -18,8 +21,8 @@ export default function JarvisPanel() {
     const fetchHistory = async () => {
       try {
         const token = typeof window !== "undefined" ? localStorage.getItem("access_token") : undefined;
-        const chat = await listChatMessages({ is_deleted: false }, token || undefined);
-        setMessages(chat as any); // Или кастни как надо
+        const chat = await listChatMessages(0, { limit: 20 }, token || undefined);
+        setMessages(chat as any);
       } catch (err) {
         setMessages([
           {


### PR DESCRIPTION
## Summary
- align Jarvis API utilities with existing backend endpoints
- update JarvisPanel to use updated API calls
- remove duplicate error types in frontend type definitions

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f073d1d8832c8ad04ec89ec50b9c