### PR TITLE
Add AI context pages and fix settings API

### DIFF
--- a/app/tests/api/test_ai_context_api.py
+++ b/app/tests/api/test_ai_context_api.py
@@ -1,0 +1,28 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.user import User as UserModel
+from app.crud.ai_context import get_ai_context
+
+@pytest.fixture
+def ai_ctx_payload():
+    return {"object_type": "project", "object_id": 1, "context_data": {"k": "v"}}
+
+
+def test_create_ai_context(client: TestClient, normal_user_token_headers: dict, db: Session, ai_ctx_payload):
+    response = client.post("/ai-context/", json=ai_ctx_payload, headers=normal_user_token_headers)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["result"]
+    ctx = get_ai_context(db, data["result"])
+    assert ctx is not None
+
+
+def test_get_ai_context(client: TestClient, normal_user_token_headers: dict, db: Session, ai_ctx_payload):
+    # create first
+    response = client.post("/ai-context/", json=ai_ctx_payload, headers=normal_user_token_headers)
+    ctx_id = response.json()["result"]
+    get_resp = client.get(f"/ai-context/{ctx_id}", headers=normal_user_token_headers)
+    assert get_resp.status_code == 200
+    assert get_resp.json()["id"] == ctx_id

--- a/app/tests/crud/test_ai_context_crud.py
+++ b/app/tests/crud/test_ai_context_crud.py
@@ -1,0 +1,24 @@
+import pytest
+from sqlalchemy.orm import Session
+from app.crud import ai_context as crud
+from app.models.ai_context import AIContext
+
+@pytest.fixture
+def ai_context_data():
+    return {
+        "object_type": "project",
+        "object_id": 1,
+        "context_data": {"notes": "test"},
+        "created_by": "tester"
+    }
+
+def test_create_ai_context(db: Session, ai_context_data):
+    ctx = crud.create_ai_context(db, **ai_context_data)
+    assert ctx.id is not None
+    assert ctx.object_type == ai_context_data["object_type"]
+
+
+def test_update_ai_context(db: Session, ai_context_data):
+    ctx = crud.create_ai_context(db, **ai_context_data)
+    updated = crud.update_ai_context(db, ctx.id, {"notes": "updated"})
+    assert updated.notes == "updated"

--- a/frontend/src/app/ai_context/[id]/page.tsx
+++ b/frontend/src/app/ai_context/[id]/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { getAIContext, deleteAIContext } from "../../lib/api";
+import { Button } from "@/components/ui/button";
+
+export default function AIContextDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [ctx, setCtx] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getAIContext(Number(id))
+      .then(setCtx)
+      .catch((e:any)=> setError(e.message || "Failed"));
+  }, [id]);
+
+  const handleDelete = async () => {
+    if(!ctx) return;
+    await deleteAIContext(ctx.id).catch(()=>{});
+    router.push('/ai_context');
+  };
+
+  if(error) return <div className="p-4 text-red-500">{error}</div>;
+  if(!ctx) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <h1 className="text-2xl font-bold mb-4">AI Context {ctx.id}</h1>
+      <pre className="mb-4 bg-gray-100 p-2 overflow-auto text-sm">{JSON.stringify(ctx, null, 2)}</pre>
+      <Button onClick={handleDelete} variant="destructive">Delete</Button>
+    </div>
+  );
+}

--- a/frontend/src/app/ai_context/new/page.tsx
+++ b/frontend/src/app/ai_context/new/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+import React, { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createAIContext } from "../../lib/api";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+export default function NewAIContextPage() {
+  const router = useRouter();
+  const [objectType, setObjectType] = useState("");
+  const [objectId, setObjectId] = useState("");
+  const [contextData, setContextData] = useState("{}");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const data = JSON.parse(contextData || "{}");
+      const created = await createAIContext({ object_type: objectType, object_id: Number(objectId), context_data: data });
+      router.push(`/ai_context/${created.id}`);
+    } catch (err: any) {
+      setError(err.message || "Failed to create");
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-8 px-4 max-w-lg">
+      <h1 className="text-2xl font-bold mb-4">New AI Context</h1>
+      {error && <div className="text-red-500 mb-2">{error}</div>}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input placeholder="object type" value={objectType} onChange={e=>setObjectType(e.target.value)} required />
+        <Input placeholder="object id" type="number" value={objectId} onChange={e=>setObjectId(e.target.value)} required />
+        <Textarea value={contextData} onChange={e=>setContextData(e.target.value)} rows={6} />
+        <Button type="submit">Create</Button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/ai_context/page.tsx
+++ b/frontend/src/app/ai_context/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import Link from "next/link";
+import { listAIContexts, AIContextRead } from "../lib/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function AIContextListPage() {
+  const [contexts, setContexts] = useState<AIContextRead[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    listAIContexts()
+      .then(setContexts)
+      .catch((e:any) => setError(e.message || "Failed to fetch"));
+  }, []);
+
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">AI Contexts</h1>
+        <Link href="/ai_context/new" legacyBehavior>
+          <Button asChild><a>New</a></Button>
+        </Link>
+      </div>
+      <div className="space-y-4">
+        {contexts.map(ctx => (
+          <Card key={ctx.id} className="dark:bg-gray-800">
+            <CardHeader>
+              <CardTitle>{ctx.object_type} #{ctx.object_id}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <pre className="text-sm overflow-auto">{JSON.stringify(ctx.context_data, null, 2)}</pre>
+              <Link href={`/ai_context/${ctx.id}`} className="text-blue-600 underline text-sm">View</Link>
+            </CardContent>
+          </Card>
+        ))}
+        {contexts.length === 0 && <p>No AI contexts yet.</p>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/lib/api.tsx
+++ b/frontend/src/app/lib/api.tsx
@@ -304,6 +304,14 @@ export function deleteSetting(id: number, token?: string | null): Promise<Succes
   return apiFetch<SuccessResponse>(`/settings/${id}`, { method: "DELETE", token });
 }
 
+export function upsertSetting(key: string, data: SettingCreate, token?: string | null): Promise<SettingRead> {
+  return apiFetch<SettingRead>(`/settings/${key}`, { method: "PUT", body: data, token });
+}
+
+export function getEffectiveSetting(key: string, token?: string | null): Promise<SettingRead> {
+  return apiFetch<SettingRead>(`/settings/effective/${key}`, { token });
+}
+
 // --- TEMPLATE ---
 export function listTemplates(params: TemplateFilters = {}, token?: string | null): Promise<TemplateShort[]> {
   return apiFetch<TemplateShort[]>("/templates/", { params, token });
@@ -384,3 +392,6 @@ export function lastChatMessages(
   if (n !== undefined) params.n = n;
   return apiFetch<ChatMessageShort[]>(`/jarvis/history/${projectId}/last`, { params, token });
 }
+
+export * from './types';
+export type SettingValue = string | number | boolean | Record<string, any>;

--- a/frontend/src/app/lib/types.tsx
+++ b/frontend/src/app/lib/types.tsx
@@ -387,6 +387,8 @@ export interface SettingRead extends SettingBase {
   updated_at: string;
 }
 
+export type SettingValue = string | number | boolean | Record<string, any>;
+
 // --- Template ---
 export interface TemplateBase {
   name: string;


### PR DESCRIPTION
## Summary
- implement AIContext frontend pages (list/detail/create)
- fix settings page types and API usage
- add SettingValue type and new API helpers
- add basic AI context CRUD and API tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6843fdfd8f1c832cbaa130d6faefd4af